### PR TITLE
Fix for memory leak caused due to missing decrefs

### DIFF
--- a/Python/wgdbmodule.c
+++ b/Python/wgdbmodule.c
@@ -1464,6 +1464,7 @@ static int parse_query_params(PyObject *self, PyObject *args,
         if(!PyTuple_Check(t) || PyTuple_Size(t) != 3) {
           PyErr_SetString(PyExc_ValueError,
             "Query arglist item must be a 3-tuple.");
+          Py_DECREF(t);
           return 0;
         }
 
@@ -1475,6 +1476,7 @@ static int parse_query_params(PyObject *self, PyObject *args,
         if(col==-1 && PyErr_Occurred()) {
           PyErr_SetString(PyExc_ValueError,
             "Failed to convert query argument column number.");
+          Py_DECREF(t);
           return 0;
         }
 
@@ -1486,12 +1488,14 @@ static int parse_query_params(PyObject *self, PyObject *args,
         if(cond==-1 && PyErr_Occurred()) {
           PyErr_SetString(PyExc_ValueError,
             "Failed to convert query argument condition.");
+          Py_DECREF(t);
           return 0;
         }
 
         enc = encode_pyobject_ext(self, query->db, PyTuple_GetItem(t, 2), 1);
         if(enc==WG_ILLEGAL) {
           /* Error set by encode function */
+          Py_DECREF(t);
           return 0;
         }
 
@@ -1504,6 +1508,7 @@ static int parse_query_params(PyObject *self, PyObject *args,
                         * not setting this to len immediately, because
                         * there might be an encoding error and part of
                         * the arguments may be left uninitialized. */
+        Py_DECREF(t);
       }
     }
   }
@@ -1531,8 +1536,9 @@ static int parse_query_params(PyObject *self, PyObject *args,
         memset(query->matchrec, 0, len * sizeof(wg_int));
 
         for(i=0; i<len; i++) {
-          wg_int enc = encode_pyobject_ext(self, query->db,
-            PySequence_GetItem(matchrec, i), 1);
+          PyObject *sg_t = PySequence_GetItem(matchrec, i);
+          wg_int enc = encode_pyobject_ext(self, query->db, sg_t, 1);
+          Py_DECREF(sg_t);
           if(enc==WG_ILLEGAL) {
             /* Error set by encode function */
             return 0;


### PR DESCRIPTION
We found the following test causes the memory footprint to constantly increase on the process: http://pastebin.com/8CAe1uT6

Please verify, make necessary changes and merge.
