### PR TITLE
Ensure that all compile*.sh scripts use the CC env var

### DIFF
--- a/Examples/compile_demo.sh
+++ b/Examples/compile_demo.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-COMPILER="cc"
+[ -z "$CC" ] && CC="cc"
 
-[[ -z "$CC" ]] || COMPILER="$CC"
-
-if [[ -z "$COMPILER" && -z "$(which $COMPILER 2>/dev/null)" ]]; then
+if [ -z "$(which $CC 2>/dev/null)" ]; then
     echo "Error: No compiler found"
     exit 1
 fi
@@ -15,6 +13,6 @@ if [ ! -f ../whitedb.c ]; then
 fi
 
 # use output of unite.sh
-$COMPILER  -O2 -I.. -o demo  demo.c ../whitedb.c -lm
+$CC -O2 -I.. -o demo  demo.c ../whitedb.c -lm
 
-#$COMPILER  -O2 -o demo  demo.c ../Db/dbmem.c ../Db/dballoc.c ../Db/dbdata.c ../Db/dblock.c ../Db/dbindex.c ../Db/dblog.c ../Db/dbhash.c ../Db/dbcompare.c ../Db/dbquery.c ../Db/dbutil.c ../Db/dbmpool.c ../Db/dbjson.c ../Db/dbschema.c ../json/yajl_all.c -lm
+#$CC  -O2 -o demo  demo.c ../Db/dbmem.c ../Db/dballoc.c ../Db/dbdata.c ../Db/dblock.c ../Db/dbindex.c ../Db/dblog.c ../Db/dbhash.c ../Db/dbcompare.c ../Db/dbquery.c ../Db/dbutil.c ../Db/dbmpool.c ../Db/dbjson.c ../Db/dbschema.c ../json/yajl_all.c -lm

--- a/Examples/compile_query.sh
+++ b/Examples/compile_query.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-COMPILER="cc"
+[ -z "$CC" ] && CC="cc"
 
-[[ -z "$CC" ]] || COMPILER="$CC"
-
-if [[ -z "$COMPILER" && -z "$(which $COMPILER 2>/dev/null)" ]]; then
+if [ -z "$(which $CC 2>/dev/null)" ]; then
     echo "Error: No compiler found"
     exit 1
 fi
@@ -15,6 +13,6 @@ if [ ! -f ../whitedb.c ]; then
 fi
 
 # use output of unite.sh
-$COMPILER  -O2 -I.. -o query  query.c ../Test/dbtest.c ../whitedb.c -lm
+$CC -O2 -I.. -o query  query.c ../Test/dbtest.c ../whitedb.c -lm
 
-#$COMPILER  -O2 -o query  query.c ../Db/dbmem.c ../Db/dballoc.c ../Db/dbdata.c ../Db/dblock.c ../Db/dbindex.c ../Db/dblog.c ../Db/dbhash.c ../Db/dbcompare.c ../Db/dbquery.c ../Db/dbutil.c  ../Test/dbtest.c ../Db/dbmpool.c ../Db/dbjson.c ../Db/dbschema.c ../json/yajl_all.c -lm
+#$CC -O2 -o query  query.c ../Db/dbmem.c ../Db/dballoc.c ../Db/dbdata.c ../Db/dblock.c ../Db/dbindex.c ../Db/dblog.c ../Db/dbhash.c ../Db/dbcompare.c ../Db/dbquery.c ../Db/dbutil.c  ../Test/dbtest.c ../Db/dbmpool.c ../Db/dbjson.c ../Db/dbschema.c ../json/yajl_all.c -lm

--- a/Python/compile.sh
+++ b/Python/compile.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-COMPILER="cc"
+[ -z "$CC" ] && CC="cc"
 
-[[ -z "$CC" ]] || COMPILER="$CC"
-
-if [[ -z "$COMPILER" && -z "$(which $COMPILER 2>/dev/null)" ]]; then
+if [ -z "$(which $CC 2>/dev/null)" ]; then
     echo "Error: No compiler found"
     exit 1
 fi
@@ -16,6 +14,6 @@ if [ ! -f ../whitedb.c ]; then
   cd ..; ./unite.sh; cd "$OLDPWD"
 fi
 
-$COMPILER -O3 -Wall -fPIC -shared -I.. -I../Db -I${PYDIR} -o wgdb.so wgdbmodule.c ../whitedb.c
+$CC -O3 -Wall -fPIC -shared -I.. -I../Db -I${PYDIR} -o wgdb.so wgdbmodule.c ../whitedb.c
 
-#$COMPILER -O3 -Wall -fPIC -shared -I../Db -I${PYDIR} -o wgdb.so wgdbmodule.c ../Db/dbmem.c ../Db/dballoc.c ../Db/dbdata.c ../Db/dblock.c ../Db/dbindex.c ../Db/dblog.c ../Db/dbhash.c  ../Db/dbcompare.c ../Db/dbquery.c ../Db/dbutil.c ../Db/dbmpool.c ../Db/dbjson.c ../Db/dbschema.c ../json/yajl_all.c
+#$CC -O3 -Wall -fPIC -shared -I../Db -I${PYDIR} -o wgdb.so wgdbmodule.c ../Db/dbmem.c ../Db/dballoc.c ../Db/dbdata.c ../Db/dblock.c ../Db/dbindex.c ../Db/dblog.c ../Db/dbhash.c  ../Db/dbcompare.c ../Db/dbquery.c ../Db/dbutil.c ../Db/dbmpool.c ../Db/dbjson.c ../Db/dbschema.c ../json/yajl_all.c

--- a/Server/compile.sh
+++ b/Server/compile.sh
@@ -3,11 +3,9 @@
 # alternative to compiling dserve and dservehttps with automake/make: 
 # just run it in the Server folder
 
-COMPILER="cc"
+[ -z "$CC" ] && CC="cc"
 
-[[ -z "$CC" ]] || COMPILER="$CC"
-
-if [[ -z "$COMPILER" && -z "$(which $COMPILER 2>/dev/null)" ]]; then
+if [ -z "$(which $CC 2>/dev/null)" ]; then
     echo "Error: No compiler found"
     exit 1
 fi
@@ -24,8 +22,8 @@ if [ ! -f ../whitedb.c ]; then
 fi
 
 # compile dserve
-$COMPILER  -O2 -Wall -I.. -o dserve dserve.c dserve_util.c dserve_net.c \
+$CC -O2 -Wall -I.. -o dserve dserve.c dserve_util.c dserve_net.c \
   ../whitedb.c -lm -lpthread
 # compile dservehttps  
-$COMPILER  -O2 -Wall -I.. -DUSE_OPENSSL -o dservehttps dserve.c dserve_util.c dserve_net.c \
+$CC -O2 -Wall -I.. -DUSE_OPENSSL -o dservehttps dserve.c dserve_util.c dserve_net.c \
   ../whitedb.c -lm -lpthread -lssl -lcrypto

--- a/compile.sh
+++ b/compile.sh
@@ -4,11 +4,9 @@
 
 # current version does not build reasoner: added later
 
-COMPILER="cc"
+[ -z "$CC" ] && CC="cc"
 
-[[ -z "$CC" ]] || COMPILER="$CC"
-
-if [[ -z "$COMPILER" && -z "$(which $COMPILER 2>/dev/null)" ]]; then
+if [ -z "$(which $CC 2>/dev/null)" ]; then
     echo "Error: No compiler found"
     exit 1
 fi
@@ -17,16 +15,16 @@ fi
 if [ config-gcc.h -nt config.h ]; then
   echo "Warning: config.h is older than config-gcc.h, consider updating it"
 fi
-${COMPILER} -O2 -Wall -o Main/wgdb Main/wgdb.c Db/dbmem.c \
+${CC} -O2 -Wall -o Main/wgdb Main/wgdb.c Db/dbmem.c \
   Db/dballoc.c Db/dbdata.c Db/dblock.c Db/dbindex.c Db/dbdump.c  \
   Db/dblog.c Db/dbhash.c Db/dbcompare.c Db/dbquery.c Db/dbutil.c Db/dbmpool.c \
   Db/dbjson.c Db/dbschema.c json/yajl_all.c -lm
 # debug and testing programs: uncomment as needed
-#$COMPILER  -O2 -Wall -o Main/indextool  Main/indextool.c Db/dbmem.c \
+#$CC  -O2 -Wall -o Main/indextool  Main/indextool.c Db/dbmem.c \
 #  Db/dballoc.c Db/dbdata.c Db/dblock.c Db/dbindex.c Db/dblog.c \
 #  Db/dbhash.c Db/dbcompare.c Db/dbquery.c Db/dbutil.c Db/dbmpool.c \
 #  Db/dbjson.c Db/dbschema.c json/yajl_all.c -lm
-#$COMPILER  -O2 -Wall -o Main/selftest Main/selftest.c Db/dbmem.c \
+#$CC  -O2 -Wall -o Main/selftest Main/selftest.c Db/dbmem.c \
 #  Db/dballoc.c Db/dbdata.c Db/dblock.c Db/dbindex.c Test/dbtest.c Db/dbdump.c \
 #  Db/dblog.c Db/dbhash.c Db/dbcompare.c Db/dbquery.c Db/dbutil.c Db/dbmpool.c \
 #  Db/dbjson.c Db/dbschema.c json/yajl_all.c -lm


### PR DESCRIPTION
These commits fixes issues where the user would have to edit the simple compilation scripts in order to build with their desired compiler.
Now, certain issues may still be present, which is why this pull request should be checked and tested first.
For the most part though, it should really just work by running the script, and using a different compiler can easily be specified through the use of the CC environment variable.

For instance, to compile using clang:

```
CC=clang ./compile.sh
```
