### PR TITLE
Added support for pkg-config.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,8 +49,14 @@ EXTRA_DIST = Bootstrap README INSTALL MANIFEST GPLLICENCE NEWS AUTHORS \
  Python/compile.bat Python/compile.sh Python/tests.py \
  Parser/dbotter.y Parser/dbotter.l Parser/dbprolog.y Parser/dbprolog.l \
  Rexamples \
- Test/common.test Test/log.test
+ Test/common.test Test/log.test \
+ whitedb.pc.in
 
 # this conflicts with the distcheck target, so disabled for now.
 #dist-hook:
 #	cp $(top_distdir)/config-gcc.h $(top_distdir)/config.h
+
+# -------- Pkg-config ---------------
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = whitedb.pc

--- a/configure.ac
+++ b/configure.ac
@@ -276,6 +276,8 @@ AC_DEFINE([VERSION_MAJOR], [WHITEDB_MAJOR], [Package major version])
 AC_DEFINE([VERSION_MINOR], [WHITEDB_MINOR], [Package minor version])
 AC_DEFINE([VERSION_REV], [WHITEDB_REV], [Package revision number])
 
+AC_CONFIG_FILES([whitedb.pc])
+
 AC_OUTPUT([
 Makefile
 Db/Makefile

--- a/whitedb.pc.in
+++ b/whitedb.pc.in
@@ -1,0 +1,12 @@
+# $Id$
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: whitedb
+Description: WhiteDB is a lightweight NoSQL database library written in C, operating fully in main memory.
+URL: http://whitedb.org
+Version: @VERSION@
+Libs: -L${libdir} -lwgdb
+Cflags: -I${includedir}


### PR DESCRIPTION
This pull request adds support for [pkg-config](https://en.wikipedia.org/wiki/Pkg-config), a standard tool in Linux and other UNIX-like operating systems.  Compilation of something like the tutorial examples now becomes something like:

```Bash
clang -Wall -Wextra -pedantic -std=c11 `pkg-config whitedb --cflags --libs` tut7.c
```

which is portable across systems regardless of where whitedb is actually installed.